### PR TITLE
Made syntax compatible with node v4

### DIFF
--- a/DomainResponse.js
+++ b/DomainResponse.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class DomainResponse {
   constructor(data) {
     return {

--- a/index.js
+++ b/index.js
@@ -132,7 +132,8 @@ class ServerlessCustomDomain {
     this.givenDomainName = givenDomainName;
   }
 
-  setEndpointType(endpointType = endpointTypes.edge) {
+  setEndpointType(endpointType) {
+    endpointType = endpointType || endpointTypes.edge;
     if (!Object.keys(endpointTypes).includes(endpointType.toLowerCase())) throw new Error(`${endpointType} is not supported endpointType, use edge or regional.`);
     this.endpointType = endpointTypes[endpointType.toLowerCase()];
   }


### PR DESCRIPTION
- Put DomainResponse.js in strict mode to allow the class declaration.
- Removed default parameter from `setEndpointType` in index.js.