### PR TITLE
Removed dependency on Array.prototype.includes

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,8 +134,9 @@ class ServerlessCustomDomain {
 
   setEndpointType(endpointType) {
     const endpointTypeWithDefault = endpointType || endpointTypes.edge;
-    if (!Object.keys(endpointTypes).includes(endpointTypeWithDefault.toLowerCase())) throw new Error(`${endpointTypeWithDefault} is not supported endpointType, use edge or regional.`);
-    this.endpointType = endpointTypes[endpointTypeWithDefault.toLowerCase()];
+    const endpointTypeToUse = endpointTypes[endpointTypeWithDefault.toLowerCase()];
+    if (!endpointTypeToUse) throw new Error(`${endpointTypeWithDefault} is not supported endpointType, use edge or regional.`);
+    this.endpointType = endpointTypeToUse;
   }
 
   setAcmRegion() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-domain-manager",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Tested under node 4 by manually transpiling index.test.js using Babel CLI and then running `npm test`.

```
  Custom Domain Plugin
    ✓ check aws config (40ms)
    Domain Endpoint types
      ✓ Unsupported endpoint types throw exception
    Set Domain Name and Base Path
      ✓ Find Deployment Id
      ✓ Add Resources to Serverless Config
      ✓ Add Domain Name, Distribution Name and Regional Name to stack output
      ✓ (none) is added if basepath is an empty string
      ✓ (none) is added if no value is given for basepath (null)
      ✓ (none) is added if basepath attribute is missing (undefined)
      ✓ stage was not given
    Create a New Domain Name
      ✓ Get the certificate arn
      ✓ Get a given certificate arn
      ✓ Create a domain name
      ✓ Migrate legacy CNAME records to A Alias
      ✓ Create a new A Alias Record
      ✓ Do not create a Route53 record
    Resource ApiGatewayStage overridden
      ✓ serverless.yml doesn't define explicitly the resource ApiGatewayStage
      ✓ serverless.yml defines explicitly the resource ApiGatewayStage
    Delete the new domain
      ✓ Find available domains
      ✓ Delete A Alias Record
      ✓ Delete the domain name
    Hook Methods
      ✓ setupBasePathMapping
      ✓ deleteDomain
      ✓ createDomain
    Select Hosted Zone
      ✓ Natural order
      ✓ Reverse order
      ✓ Random order
      ✓ Sub domain name - only root hosted zones
      ✓ With matching root and sub hosted zone
      ✓ Sub domain name - natural order
      ✓ Sub domain name - reverse order
      ✓ Sub domain name - random order
    Error Catching
      ✓ If a certificate cannot be found when a name is given
      ✓ Fail getHostedZone
      ✓ Domain summary failed
      ✓ Catch failure of record type migration
    Summary Printing
      ✓ Prints Summary
    Enable/disable functionality
      ✓ Should enable the plugin by default
      ✓ Should enable the plugin when passing a true parameter
      ✓ Should disable the plugin when passing a false parameter
      ✓ createDomain should do nothing and report that the plugin is disabled
      ✓ deleteDomain should do nothing and report that the plugin is disabled
      ✓ setUpBasePathMapping should do nothing and report that the plugin is disabled
      ✓ domainSummary should do nothing and report that the plugin is disabled
      ✓ Should throw an Error when passing a parameter that is not boolean


  44 passing (232ms)

=============================================================================
Writing coverage object [/mnt/storage1/home/ejherbertson/github/serverless-domain-manager/coverage/coverage.json]
Writing coverage reports at [/mnt/storage1/home/ejherbertson/github/serverless-domain-manager/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 88.54% ( 170/192 )
Branches     : 78.89% ( 71/90 )
Functions    : 100% ( 22/22 )
Lines        : 89.19% ( 165/185 )
================================================================================
```